### PR TITLE
Conversation: decorate `v`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vella",
-    "version": "0.0.1",
+    "version": "0.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/v.js
+++ b/src/v.js
@@ -1,0 +1,6 @@
+import * as render from './render.js'
+
+const { boot, v, S: s } = render
+const { root, data, value, sample, on } = s
+Object.assign(v, { boot, root, data, value, sample, on, s })
+export { v }


### PR DESCRIPTION
This isn't intended to necessarily be the final resting place for this functionality; I'd just like to submit that the DX of building the small vella projects I've attempted thus far has been improved using this API. The single import is certainly nice, as is the cohesive feel of the `v` prefix for all v/S activities.