### PR TITLE
import/export file extensions are mandatory for Node/esm

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,4 @@ export {
 } from "./src/render.js"
 export {
 	setDocument
-} from "./src/util"
+} from "./src/util.js"


### PR DESCRIPTION
tests need to import setDocument, which is borked without this.